### PR TITLE
Added support for NIL results for Custom objects

### DIFF
--- a/Classes/NSObject+Foundry.m
+++ b/Classes/NSObject+Foundry.m
@@ -125,8 +125,14 @@
                 [attributesDict setObject:[[NSUUID UUID] UUIDString] forKey:key];
                 break;
             case FoundryPropertyTypeCustom:
-                [attributesDict setObject:[self foundryAttributeForProperty:key] forKey:key];
+            {
+                id  value = [self foundryAttributeForProperty:key];
+                if (value)
+                {
+                    [attributesDict setObject:value forKey:key];
+                }
                 break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
Check return value from 'foundryAttributeForProperty:' and only add to attributesDict if not nil.

Signed-off-by: Darren Ehlers me@darrenehlers.com
