### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ What we really need is something like [factory_girl](https://github.com/thoughtb
 
 ## Using Foundry
 
-Enter Foundry.  It aims to solve all of these problems by giving you easy ways to mint model objects using "real" data with special handling for Core Data entities and runtime property setting.  All we have to do to get started (after installing Foundry using Cocoapods and importing the "Foundry.h" header) is to take our Person model and adopt the TGFoundryObject protocol.
+Enter Foundry.  It aims to solve all of these problems by giving you easy ways to mint model objects using "real" data with special handling for Core Data entities and runtime property setting.  All we have to do to get started (after installing Foundry using CocoaPods and importing the "Foundry.h" header) is to take our Person model and adopt the TGFoundryObject protocol.
 
 ### With NSObject models
 
@@ -156,7 +156,7 @@ Right now you can set these using the custom property types but very soon Foundr
 
 ## Requirements
 
-Foundry is built for use on both OSX 10.7 and above and iOS 6.0 and above.  Your best bet to to install using Cocoapods.  
+Foundry is built for use on both OSX 10.7 and above and iOS 6.0 and above.  Your best bet to to install using CocoaPods.  
 
 If you want to run the test suite, clone the repo, run "pod install" in the main directory and then do "rake spec".
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
